### PR TITLE
Get categories id's from custom lti params & faculty groups

### DIFF
--- a/app/Http/Controllers/FacultyController.php
+++ b/app/Http/Controllers/FacultyController.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Responses\SuccessResponse;
+
+class FacultyController extends Controller
+{
+    public function index(): SuccessResponse
+    {
+        $settings = collect(session('settings'));
+
+        $faculties = $settings->filter(function ($value, $key) {
+            return strpos($key, 'faculty_option') !== false;
+        });
+
+        return new SuccessResponse($faculties->values()->toArray());
+    }
+}

--- a/app/Http/Requests/Group/AddUserToGroupsRequest.php
+++ b/app/Http/Requests/Group/AddUserToGroupsRequest.php
@@ -18,6 +18,7 @@ class AddUserToGroupsRequest extends FormRequest
             'school' => 'required|array',
             'school.name' => 'required|string',
             'school.description' => 'required|string',
+            'faculty' => 'string',
         ];
     }
 }

--- a/resources/views/lti/index.blade.php
+++ b/resources/views/lti/index.blade.php
@@ -4,7 +4,6 @@
 <div class="card">
     <div class="card-body">
         <group-enroll-view>
-            v-if="window.cookie">
         </group-enroll-view>
     </div>
 </div>

--- a/routes/api.php
+++ b/routes/api.php
@@ -18,6 +18,10 @@ Route::group(['prefix' => 'enrollment', 'middleware' => 'lti'], function() {
     Route::post('/', 'EnrollmentController@store');
 });
 
+Route::group(['prefix' => 'faculties', 'middleware' => 'lti'], function() {
+    Route::get('/', 'FacultyController@index');
+});
+
 Route::group(['prefix' => 'command'], function() {
     Route::get('migrate', 'CommandController@migrate');
 });


### PR DESCRIPTION
To test this pull request you have to paste this under "Custom params" in LTI app configuration: 
FACULTY_CATEGORY_ID=3
FACULTY_OPTION_1=Matematikk 1-71
county_category_id=1
community_category_id=2
school_category_id=3
county_principals_category_id=4
community_principals_category_id=5
county_faculty_category_id=6
community_faculty_category_id=7 